### PR TITLE
Fix typo on sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
         <li><a href="#f-minimum">minimum</a></li> 
         <li><a href="#f-scan">scan</a></li> 
         <li><a href="#f-scan1">scan1</a></li> 
-        <li><a href="#f-scanr">scar</a></li> 
+        <li><a href="#f-scanr">scanr</a></li> 
         <li><a href="#f-scanr1">scanr1</a></li> 
         <li><a href="#f-replicate">replicate</a></li> 
         <li><a href="#f-take">take</a></li> 


### PR DESCRIPTION
On the main page sidebar, the function "scanr" was listed as "scar." This (tiny tiny) pull request fixes that.
