### PR TITLE
fix, use export, revert the "[1 to]"

### DIFF
--- a/prelude.ls
+++ b/prelude.ls
@@ -201,7 +201,7 @@ export mean = export average = (xs) -> (sum xs) / len xs
 
 export concat = (xss) -> fold append, [], xss
 
-export concatMap = (f, xs) --> fold ((memo, x) -> memo +++ f x), [], xs
+export concatMap = (f, xs) --> fold ((memo, x) -> append memo, f x), [], xs
 
 export listToObj = (xs) ->
   {[x.0, x.1] for x in xs}


### PR DESCRIPTION
"[1 to]" will use [].slice, whereas we may want ''.slice

As I commented on my first PR, "concatMap" returns a map, which makes this test fail :

`eq 'AABBCCDD' concatMap (-> it.toUpperCase!), ['aa' 'bb' 'cc' 'dd']`
(returns AA,BB,CC,DD)

WIP - @michaelficarra any remark on this one ;) ?
