### PR TITLE
wth 'ut8' charset. should be `utf-8`

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-  <meta charset='ut8'>
+  <meta charset='utf-8'>
   <title>prelude.ls - a functionally oriented utility library in LiveScript</title>
   <meta name='description' content="prelude.ls is a functionally oriented utility library - powerful and flexible, almost all of functions are curried. It is written in, and is the recommended base library for, LiveScript.">
 


### PR DESCRIPTION
my library can't decode `ut8` charset

```
# in private IRC channel
<keedi> hshong: http://preludels.com/ 혹시 이것도 쓰세요?
<misskim> [Unknown encoding 'ut8' at lib/Hubot/Scripts/shorten.pm line 77.
```
