### PR TITLE
Map ok

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "uglify-js": "~2.4.12",
     "mocha": "~2.2.4",
     "istanbul": "~0.2.4",
-    "browserify": "~3.24.13",
+    "browserify": "^13.0.1",
     "sinon": "~1.10.2"
   }
 }

--- a/src/List.ls
+++ b/src/List.ls
@@ -6,6 +6,9 @@ each = (f, xs) -->
 map = (f, xs) -->
   [f x for x in xs]
 
+map-ok = (f, xs) -->
+  [res for x in xs when (res = f x)?]
+
 compact = (xs) -->
   [x for x in xs when x]
 
@@ -327,7 +330,7 @@ find-indices = (f, xs) -->
   [i for x, i in xs when f x]
 
 module.exports = {
-  each, map, filter, compact, reject, remove, partition, find,
+  each, map, map-ok, filter, compact, reject, remove, partition, find,
   head, first, tail, last, initial, empty,
   reverse, difference, intersection, union, count-by, group-by,
   fold, fold1, foldl, foldl1, foldr, foldr1, unfoldr, and-list, or-list,

--- a/src/index.ls
+++ b/src/index.ls
@@ -24,7 +24,7 @@ prelude = {
   replicate,
 }
 prelude <<< List{
-  each, map, filter, compact, reject, partition, find,
+  each, map, map-ok, filter, compact, reject, partition, find,
   head, first, tail, last, initial, empty,
   reverse, difference, intersection, union, count-by, group-by,
   fold, foldl, fold1, foldl1, foldr, foldr1, unfoldr, and-list, or-list,

--- a/test/List.ls
+++ b/test/List.ls
@@ -2,7 +2,7 @@
   id
   Num: {even, odd, floor, is-it-NaN}
   List: {
-    each, map, filter, compact, reject, remove, partition, find,
+    each, map, map-ok, filter, compact, reject, remove, partition, find,
     head, first, tail, last, initial, empty,
     reverse, difference, intersection, union, count-by, group-by,
     fold, fold1, foldl, foldl1, foldr, foldr1, unfoldr, and-list, or-list,
@@ -38,6 +38,28 @@ suite 'map' ->
   test 'curried' ->
     f = map (+ 1)
     deep-eq [2 3 4], f [1 2 3]
+
+suite 'map-ok' ->
+  test 'empty list as input' ->
+    deep-eq [], map-ok id, []
+
+  test 'mapping over array, no undefineds' ->
+    deep-eq [2 3 4 5 6], map-ok do
+        -> it + 1
+        [1 2 3 4 5]
+
+  test 'mapping over array, with undefineds' ->
+    deep-eq [3 5 7], map-ok do
+        -> it + 1 unless it % 2
+        [1 2 3 4 5 6]
+
+  test 'curried, no undefineds' ->
+    f = map-ok -> it + 1
+    deep-eq [2 3 4 5 6 7], f [1 2 3 4 5 6]
+
+  test 'curried, with undefineds' ->
+    f = map-ok -> it + 1 unless it % 2
+    deep-eq [3 5 7], f [1 2 3 4 5 6]
 
 suite 'compact' ->
   test 'empty list as input' ->


### PR DESCRIPTION
Hi,

My proposal is a ```map-ok``` function, which is identical to ```map```, except that returning ```undefined``` or ```null``` will remove the element from the output list.

The use case is that I often find myself wanting to remove an element while I'm mapping, and end up using an extra ```compact```. It would be nice to be able to do it the first time around. (cf. Perl, for example, where you can return ```()```).

Note that this implementation will also remove elements that were ```undefined``` or ```null``` to begin with in the input list. But I believe that won't confuse most people.