### PR TITLE
Added `map-keys`

### DIFF
--- a/src/Obj.ls
+++ b/src/Obj.ls
@@ -32,6 +32,9 @@ each = (f, object) -->
 map = (f, object) -->
   {[k, f x] for k, x of object}
 
+map-keys = (f, object) -->
+  {[f k; x] for k, x of object}
+
 compact = (object) -->
   {[k, x] for k, x of object when x}
 
@@ -56,5 +59,5 @@ module.exports = {
   values, keys,
   pairs-to-obj, obj-to-pairs, lists-to-obj, obj-to-lists,
 
-  empty, each, map, filter, compact, reject, partition, find,
+  empty, each, map, map-keys, filter, compact, reject, partition, find,
 }

--- a/src/index.ls
+++ b/src/index.ls
@@ -47,6 +47,7 @@ prelude <<< Str{
 prelude <<< Obj{
   values, keys,
   pairs-to-obj, obj-to-pairs, lists-to-obj, obj-to-lists,
+  map-keys,
 }
 prelude <<< Num{
   max, min, negate, abs, signum, quot, rem, div, mod, recip,

--- a/test/Obj.ls
+++ b/test/Obj.ls
@@ -3,7 +3,7 @@
   Obj: {
     values, keys,
     pairs-to-obj, obj-to-pairs, lists-to-obj, obj-to-lists,
-    empty, each, map, filter, compact, reject, partition, find,
+    empty, each, map, map-keys, filter, compact, reject, partition, find,
   }
 } = require '..'
 {strict-equal: eq, deep-equal: deep-eq, ok} = require 'assert'
@@ -92,6 +92,17 @@ suite 'map' ->
   test 'curried' ->
     f = map (* 2)
     deep-eq {a:2, b:4}, f {a:1, b:2}
+
+suite 'map-keys' ->
+  test 'empty object as input' ->
+    deep-eq {}, map-keys id, {}
+
+  test 'mapping keys of object' ->
+    deep-eq {za:1, zb:2}, map-keys ('z' +), {a:1, b:2}
+
+  test 'curried' ->
+    f = map-keys ('z' +)
+    deep-eq {za:1, zb:2}, f {a:1, b:2}
 
 suite 'compact' ->
   test 'empty object as input' ->


### PR DESCRIPTION
Definition of `map-keys`:
Applies a function to each key of the object, and produces a new object with the new keys and the same values. The size of the result is the same size as the input.
