### PR TITLE
Fix repository URL protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/gkz/prelude-ls.git"
+    "url": "https://github.com/gkz/prelude-ls.git"
   },
   "scripts": {
     "test": "make test"

--- a/package.json.ls
+++ b/package.json.ls
@@ -32,7 +32,7 @@ engines:
   node: '>= 0.8.0'
 repository:
   type: 'git'
-  url: 'git://github.com/gkz/prelude-ls.git'
+  url: 'https://github.com/gkz/prelude-ls.git'
 scripts:
   test: "make test"
 


### PR DESCRIPTION
This updates the package metadata repository URL from the legacy `git://` protocol to HTTPS in both `package.json` and `package.json.ls`.

The `git://` protocol is unauthenticated and may be blocked on some networks, while the HTTPS GitHub URL is directly accessible to npm users and tooling.

Validation:
- Parsed `package.json` and asserted `repository.url`
- `git diff --check`
- `npm install --ignore-scripts`
- `npm test`

Note: `npm install` reports existing dependency audit warnings in this older dependency tree; this PR does not change dependencies or the lockfile.